### PR TITLE
feat(lambda): archive on-site notifications past their relevance

### DIFF
--- a/pnpm-monorepo/apps/app/src/modules/audit/utils/AuditEventTypes.ts
+++ b/pnpm-monorepo/apps/app/src/modules/audit/utils/AuditEventTypes.ts
@@ -141,6 +141,7 @@ export enum AuditEventType {
   ON_SITE_NOTIFICATION_ARCHIVED = "ON_SITE_NOTIFICATION_ARCHIVED",
   ON_SITE_NOTIFICATIONS_READ_ARCHIVED = "ON_SITE_NOTIFICATIONS_READ_ARCHIVED",
   ON_SITE_NOTIFICATION_UNARCHIVED = "ON_SITE_NOTIFICATION_UNARCHIVED",
+  IRRELEVANT_ON_SITE_NOTIFICATIONS_ARCHIVED = "IRRELEVANT_ON_SITE_NOTIFICATIONS_ARCHIVED",
   WEB_PUSH_SUBSCRIPTIONS_PRUNED = "WEB_PUSH_SUBSCRIPTIONS_PRUNED",
   CHANGELOG_ENTRIES_SEEN = "CHANGELOG_ENTRIES_SEEN",
   UNUSED_UPLOADS_DELETED = "UNUSED_UPLOADS_DELETED",
@@ -1068,6 +1069,10 @@ export interface AuditEventDataByType {
   [AuditEventType.ON_SITE_NOTIFICATION_UNARCHIVED]: {
     citizenId: string;
     notificationId: string;
+  };
+
+  [AuditEventType.IRRELEVANT_ON_SITE_NOTIFICATIONS_ARCHIVED]: {
+    count: number;
   };
 
   [AuditEventType.WEB_PUSH_SUBSCRIPTIONS_PRUNED]: {
@@ -2646,6 +2651,15 @@ export const AuditEventDefinitions: {
       notificationId: "string",
     },
     message: (data) => `Restored notification ${data.notificationId}`,
+  },
+
+  [AuditEventType.IRRELEVANT_ON_SITE_NOTIFICATIONS_ARCHIVED]: {
+    type: AuditEventType.IRRELEVANT_ON_SITE_NOTIFICATIONS_ARCHIVED,
+    data: {
+      count: 0,
+    },
+    message: (data) =>
+      `Archived ${data.count} on-site notification(s) which aren't relevant anymore`,
   },
 
   [AuditEventType.WEB_PUSH_SUBSCRIPTIONS_PRUNED]: {

--- a/pnpm-monorepo/apps/lambda/src/midnight-automations.ts
+++ b/pnpm-monorepo/apps/lambda/src/midnight-automations.ts
@@ -2,6 +2,7 @@ import "./midnight-automations/setup"; // must be first
 
 import type { ScheduledHandler } from "aws-lambda";
 import { initializeRequestContext } from "./common/requestContext";
+import { archiveIrrelevantOnSiteNotifications } from "./midnight-automations/archiveIrrelevantOnSiteNotifications";
 import { autoAssignInactiveRoles } from "./midnight-automations/autoAssignInactiveRoles";
 import { countCitizensPerRole } from "./midnight-automations/countCitizensPerRole";
 import { countShips } from "./midnight-automations/countShips";
@@ -26,6 +27,7 @@ export const handler: ScheduledHandler = async (event, context) => {
     await countUniqueLogins();
     await purgeTrashedWikiPages();
     await purgeOrphanedWikiTags();
+    await archiveIrrelevantOnSiteNotifications();
     await deleteUnusedUploads();
   });
 };

--- a/pnpm-monorepo/apps/lambda/src/midnight-automations/archiveIrrelevantOnSiteNotifications.ts
+++ b/pnpm-monorepo/apps/lambda/src/midnight-automations/archiveIrrelevantOnSiteNotifications.ts
@@ -1,0 +1,62 @@
+import { prisma } from "@sam-monorepo/database";
+import { type OnSiteNotificationType } from "@sam-monorepo/notifications";
+import { createAuditEvents } from "../common/audit";
+import { log } from "../common/logger";
+import { captureAsyncFunc } from "../common/xray";
+
+/**
+ * How long a notification of a given type stays relevant after it was
+ * created. Types without an entry stay in the inbox until the citizen
+ * archives them; only list a type here whose notification says nothing worth
+ * acting on once its window has passed.
+ *
+ * `event_starting` goes out 15 minutes before the event starts (see the
+ * frequent automation of the same name), so it is obsolete the moment the
+ * event begins.
+ */
+const RELEVANCE_MINUTES_BY_TYPE = {
+  event_starting: 15,
+} as const satisfies Partial<Record<OnSiteNotificationType, number>>;
+
+/**
+ * Archives on-site notifications whose relevance window has passed, taking
+ * them out of the inbox and the unread badge without touching their read
+ * state — the citizen can still find (and unarchive) them in the archive.
+ *
+ * Running once a day means they outlive their window by up to a day; they
+ * are merely stale, not harmful, and a browser that has one open keeps
+ * showing it until the next fetch.
+ */
+export const archiveIrrelevantOnSiteNotifications = async () => {
+  await captureAsyncFunc("archiveIrrelevantOnSiteNotifications", async () => {
+    const now = Date.now();
+
+    const result = await prisma.onSiteNotification.updateMany({
+      where: {
+        archivedAt: null,
+        OR: Object.entries(RELEVANCE_MINUTES_BY_TYPE).map(
+          ([notificationType, relevanceMinutes]) => ({
+            notificationType,
+            createdAt: { lt: new Date(now - relevanceMinutes * 60 * 1000) },
+          }),
+        ),
+      },
+      data: {
+        archivedAt: new Date(),
+      },
+    });
+
+    if (result.count > 0) {
+      log.info("Archived irrelevant on-site notifications", {
+        count: result.count,
+      });
+
+      await createAuditEvents([
+        {
+          type: "IRRELEVANT_ON_SITE_NOTIFICATIONS_ARCHIVED",
+          data: { count: result.count },
+        },
+      ]);
+    }
+  });
+};


### PR DESCRIPTION
Adds a midnight automation which archives on-site notifications whose type has a known relevance window, starting with `event_starting`.

Archiving rather than deleting keeps the notification reachable in the archive tab while taking it out of the inbox and the unread badge, which both filter on `archivedAt`.

Adding another type later is a one-line change to the relevance table.

## Verification

Ran against a local dev database: a 16-minute-old `event_starting` gets archived, a 5-minute-old one and a two-day-old `event_created` stay untouched, an already-archived row keeps its original timestamp, and the audit event is written once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aS45i7Ey61CzMDBqVWA2j