### PR TITLE
Project maintenance phase 1: live bug fixes

### DIFF
--- a/.github/workflows/validate-app.yml
+++ b/.github/workflows/validate-app.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - .github/workflows/validate-app.yml
       - pnpm-monorepo/apps/app/**
-      - pnpm-monorepo/packages/database/**
+      - pnpm-monorepo/packages/**
       - pnpm-monorepo/pnpm-lock.yaml
       - pnpm-monorepo/pnpm-workspace.yaml
   push:
@@ -16,7 +16,7 @@ on:
     paths:
       - .github/workflows/validate-app.yml
       - pnpm-monorepo/apps/app/**
-      - pnpm-monorepo/packages/database/**
+      - pnpm-monorepo/packages/**
       - pnpm-monorepo/pnpm-lock.yaml
       - pnpm-monorepo/pnpm-workspace.yaml
 

--- a/pnpm-monorepo/apps/app/src/app/app/dashboard/page.tsx
+++ b/pnpm-monorepo/apps/app/src/app/app/dashboard/page.tsx
@@ -14,13 +14,19 @@ import { Suspense } from "react";
 export default async function Page() {
   const authentication = await requireAuthenticationPage("/app/dashboard");
 
-  const [disableAlgolia, canCitizenRead, canOrgRead, canEventRead] =
-    await Promise.all([
-      getUnleashFlag(UNLEASH_FLAG.DisableAlgolia),
-      authentication.authorize("citizen", "read"),
-      authentication.authorize("organization", "read"),
-      authentication.authorize("event", "read"),
-    ]);
+  const [
+    disableAlgolia,
+    canCitizenRead,
+    canOrgRead,
+    canEventRead,
+    canTaskRead,
+  ] = await Promise.all([
+    getUnleashFlag(UNLEASH_FLAG.DisableAlgolia),
+    authentication.authorize("citizen", "read"),
+    authentication.authorize("organization", "read"),
+    authentication.authorize("event", "read"),
+    authentication.authorize("task", "read"),
+  ]);
 
   const showCalendar = canEventRead;
   const showSpynetSearchTile =
@@ -41,8 +47,12 @@ export default async function Page() {
       </div>
 
       <div className="flex flex-col gap-6 w-100 flex-none">
-        <TasksDashboardTile />
-        <LatestTasksDashboardTile />
+        {canTaskRead && (
+          <>
+            <TasksDashboardTile />
+            <LatestTasksDashboardTile />
+          </>
+        )}
 
         <section className="flex flex-col gap-0.5 flex-none">
           <h2 className="font-thin text-2xl self-start mb-2 font-mono uppercase">

--- a/pnpm-monorepo/apps/app/src/modules/auth/hooks/useAuthentication.ts
+++ b/pnpm-monorepo/apps/app/src/modules/auth/hooks/useAuthentication.ts
@@ -24,12 +24,13 @@ export const useAuthentication = () => {
   ) {
     if (!session) return false;
 
-    const enable_admin =
-      typeof document !== "undefined"
-        ? document.cookie.includes("enable_admin=1")
-        : false;
+    const adminEnabled =
+      typeof document !== "undefined" &&
+      document.cookie
+        .split(";")
+        .some((cookie) => cookie.trim() === "enable_admin=1");
 
-    if (session.user.role === "admin" && enable_admin) return session;
+    if (session.user.role === "admin" && adminEnabled) return session;
 
     const result = comparePermissionSets(
       {

--- a/pnpm-monorepo/apps/app/src/modules/common/utils/apiErrorHandler.ts
+++ b/pnpm-monorepo/apps/app/src/modules/common/utils/apiErrorHandler.ts
@@ -12,8 +12,7 @@ export default function apiErrorHandler(
     return NextResponse.json(
       {
         message: "Bad Request",
-        // @ts-expect-error
-        errors: error.errors,
+        errors: error.issues,
       },
       { status: 400, ...responseInit },
     );

--- a/pnpm-monorepo/apps/app/src/modules/common/utils/getUnleashFlag.ts
+++ b/pnpm-monorepo/apps/app/src/modules/common/utils/getUnleashFlag.ts
@@ -38,6 +38,7 @@ export const getUnleashFlag = cache(
       log.error("Error fetching feature flag", {
         error: serializeError(error),
       });
+      return false;
     }
   }),
 );

--- a/pnpm-monorepo/apps/app/src/modules/preview-channel/utils/useTimeLeft.ts
+++ b/pnpm-monorepo/apps/app/src/modules/preview-channel/utils/useTimeLeft.ts
@@ -14,7 +14,7 @@ export const useTimeLeft = (date: Date) => {
     return () => {
       clearInterval(interval);
     };
-  });
+  }, [date]);
 
   return timeLeft;
 };

--- a/pnpm-monorepo/apps/app/src/modules/profit-distribution/actions/endCollectionPhase.ts
+++ b/pnpm-monorepo/apps/app/src/modules/profit-distribution/actions/endCollectionPhase.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/db";
 import { createAuthenticatedAction } from "@/modules/actions/utils/createAction";
 import { AuditEventType } from "@/modules/audit/utils/AuditEventTypes";
 import { createAuditEvents } from "@/modules/audit/utils/createAuditEvent";
+import { triggerNotifications } from "@/modules/notifications/utils/triggerNotification";
 import { updateCitizensSilcBalances } from "@/modules/silc/utils/updateCitizensSilcBalances";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
@@ -55,7 +56,19 @@ export const endCollectionPhase = createAuthenticatedAction(
       },
     });
 
-    await prisma.$transaction([
+    const [createdSilcTransactions] = await prisma.$transaction([
+      prisma.silcTransaction.createManyAndReturn({
+        data: allSilcBalances.map((citizen) => ({
+          receiverId: citizen.id,
+          value: -citizen.silcBalance,
+          description: `SINcome: ${cycle.title}`,
+          createdById: authentication.session.entity!.id,
+        })),
+        select: {
+          id: true,
+        },
+      }),
+
       prisma.profitDistributionCycle.update({
         where: {
           id: data.id,
@@ -84,15 +97,6 @@ export const endCollectionPhase = createAuthenticatedAction(
           },
         }),
       ),
-
-      prisma.silcTransaction.createMany({
-        data: allSilcBalances.map((citizen) => ({
-          receiverId: citizen.id,
-          value: -citizen.silcBalance,
-          description: `SINcome: ${cycle.title}`,
-          createdById: authentication.session.entity!.id,
-        })),
-      }),
     ]);
 
     await updateCitizensSilcBalances(
@@ -106,6 +110,20 @@ export const endCollectionPhase = createAuthenticatedAction(
           cycleId: data.id,
         },
         createdById: authentication.session.user.id,
+      },
+    ]);
+
+    /**
+     * Trigger notifications
+     */
+    await triggerNotifications([
+      {
+        type: "SilcTransactionsCreated",
+        payload: {
+          transactionIds: createdSilcTransactions.map(
+            (transaction) => transaction.id,
+          ),
+        },
       },
     ]);
 

--- a/pnpm-monorepo/apps/app/src/modules/statistics/queries/getDailyLoginStatisticChart.ts
+++ b/pnpm-monorepo/apps/app/src/modules/statistics/queries/getDailyLoginStatisticChart.ts
@@ -19,15 +19,13 @@ export const getDailyLoginStatisticChart = cache(
       },
     });
 
-    const orderedLogins = rows.map((row) => {
-      const createdAt = new Date(row.date);
-      createdAt.setDate(createdAt.getDate() + 1); // Workaround: Offset due to timezone
-
-      return {
-        createdAt,
-        count: row.count,
-      };
-    });
+    const orderedLogins = rows.map((row) => ({
+      // `date` is a DATE column (midnight UTC) naming the counted day.
+      // Europe/Berlin is always ahead of UTC, so the chart buckets it under
+      // that same calendar day.
+      createdAt: row.date,
+      count: row.count,
+    }));
 
     const totalRecords = orderedLogins.map((entry) => ({
       id: "logins",

--- a/pnpm-monorepo/apps/app/src/modules/statistics/queries/getRegisteredUserStatisticChart.ts
+++ b/pnpm-monorepo/apps/app/src/modules/statistics/queries/getRegisteredUserStatisticChart.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/db";
 import { requireAuthentication } from "@/modules/auth/server";
 import { withTrace } from "@/modules/tracing/utils/withTrace";
+import { formatInTimeZone } from "date-fns-tz";
 import { forbidden } from "next/navigation";
 import { cache } from "react";
 import {
@@ -8,6 +9,9 @@ import {
   normalizeOptions,
   type StatisticChartData,
 } from "../utils/chartData";
+
+const formatDateKey = (date: Date) =>
+  formatInTimeZone(date, "Europe/Berlin", "yyyy-MM-dd");
 
 export const getRegisteredUserStatisticChart = cache(
   withTrace("getRegisteredUserStatisticChart", async () => {
@@ -46,7 +50,7 @@ export const getRegisteredUserStatisticChart = cache(
     for (const registration of registrations) {
       if (!registration.createdAt) continue;
 
-      const dateKey = `${registration.createdAt.getFullYear()}-${registration.createdAt.getMonth()}-${registration.createdAt.getDate()}`;
+      const dateKey = formatDateKey(registration.createdAt);
       registrationsByDate.set(
         dateKey,
         (registrationsByDate.get(dateKey) ?? 0) + 1,

--- a/pnpm-monorepo/apps/app/src/modules/statistics/queries/getRoleCitizenStatisticChart.ts
+++ b/pnpm-monorepo/apps/app/src/modules/statistics/queries/getRoleCitizenStatisticChart.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/db";
 import { requireAuthentication } from "@/modules/auth/server";
 import { withTrace } from "@/modules/tracing/utils/withTrace";
+import { subHours } from "date-fns";
 import { forbidden } from "next/navigation";
 import { cache } from "react";
 import { buildChartData } from "../utils/chartData";
@@ -30,17 +31,15 @@ export const getRoleCitizenStatisticChart = cache(
       },
     });
 
-    const records = rows.map((row) => {
-      const createdAt = new Date(row.createdAt);
-      createdAt.setDate(createdAt.getDate() - 1); // Workaround: Offset due to timezone
-
-      return {
-        id: row.roleId,
-        name: row.role.name,
-        createdAt,
-        count: row.count,
-      };
-    });
+    const records = rows.map((row) => ({
+      id: row.roleId,
+      name: row.role.name,
+      // The snapshot is written moments after midnight (Europe/Berlin) and
+      // describes the day that just ended. Stepping back half a day lands
+      // inside that day regardless of DST shifts.
+      createdAt: subHours(row.createdAt, 12),
+      count: row.count,
+    }));
 
     return {
       ...buildChartData(records, configuration),

--- a/pnpm-monorepo/apps/app/src/modules/statistics/queries/getTotalCitizenStatisticChart.ts
+++ b/pnpm-monorepo/apps/app/src/modules/statistics/queries/getTotalCitizenStatisticChart.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/db";
 import { requireAuthentication } from "@/modules/auth/server";
 import { withTrace } from "@/modules/tracing/utils/withTrace";
+import { formatInTimeZone } from "date-fns-tz";
 import { forbidden } from "next/navigation";
 import { cache } from "react";
 import {
@@ -8,6 +9,9 @@ import {
   normalizeOptions,
   type StatisticChartData,
 } from "../utils/chartData";
+
+const formatDateKey = (date: Date) =>
+  formatInTimeZone(date, "Europe/Berlin", "yyyy-MM-dd");
 
 export const getTotalCitizenStatisticChart = cache(
   withTrace("getTotalCitizenStatisticChart", async () => {
@@ -44,7 +48,7 @@ export const getTotalCitizenStatisticChart = cache(
 
     const citizensByDate = new Map<string, number>();
     for (const citizen of citizens) {
-      const dateKey = `${citizen.createdAt.getFullYear()}-${citizen.createdAt.getMonth()}-${citizen.createdAt.getDate()}`;
+      const dateKey = formatDateKey(citizen.createdAt);
       citizensByDate.set(dateKey, (citizensByDate.get(dateKey) ?? 0) + 1);
     }
 

--- a/pnpm-monorepo/apps/app/src/modules/statistics/queries/getTotalOrganizationStatisticChart.ts
+++ b/pnpm-monorepo/apps/app/src/modules/statistics/queries/getTotalOrganizationStatisticChart.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/db";
 import { requireAuthentication } from "@/modules/auth/server";
 import { withTrace } from "@/modules/tracing/utils/withTrace";
+import { formatInTimeZone } from "date-fns-tz";
 import { forbidden } from "next/navigation";
 import { cache } from "react";
 import {
@@ -8,6 +9,9 @@ import {
   normalizeOptions,
   type StatisticChartData,
 } from "../utils/chartData";
+
+const formatDateKey = (date: Date) =>
+  formatInTimeZone(date, "Europe/Berlin", "yyyy-MM-dd");
 
 export const getTotalOrganizationStatisticChart = cache(
   withTrace("getTotalOrganizationStatisticChart", async () => {
@@ -44,7 +48,7 @@ export const getTotalOrganizationStatisticChart = cache(
 
     const organizationsByDate = new Map<string, number>();
     for (const organization of organizations) {
-      const dateKey = `${organization.createdAt.getFullYear()}-${organization.createdAt.getMonth()}-${organization.createdAt.getDate()}`;
+      const dateKey = formatDateKey(organization.createdAt);
       organizationsByDate.set(
         dateKey,
         (organizationsByDate.get(dateKey) ?? 0) + 1,

--- a/pnpm-monorepo/apps/app/src/modules/statistics/queries/getTotalShipStatisticChart.ts
+++ b/pnpm-monorepo/apps/app/src/modules/statistics/queries/getTotalShipStatisticChart.ts
@@ -1,9 +1,14 @@
 import { prisma } from "@/db";
 import { requireAuthentication } from "@/modules/auth/server";
 import { withTrace } from "@/modules/tracing/utils/withTrace";
+import { subHours } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { forbidden } from "next/navigation";
 import { cache } from "react";
 import { buildChartData, type StatisticChartData } from "../utils/chartData";
+
+const formatDateKey = (date: Date) =>
+  formatInTimeZone(date, "Europe/Berlin", "yyyy-MM-dd");
 
 export const getTotalShipStatisticChart = cache(
   withTrace("getTotalShipStatisticChart", async () => {
@@ -30,10 +35,12 @@ export const getTotalShipStatisticChart = cache(
     >();
 
     for (const row of rows) {
-      const createdAt = new Date(row.createdAt);
-      createdAt.setDate(createdAt.getDate() - 1); // Workaround: Offset due to timezone
+      // The snapshot is written moments after midnight (Europe/Berlin) and
+      // describes the day that just ended. Stepping back half a day lands
+      // inside that day regardless of DST shifts.
+      const createdAt = subHours(row.createdAt, 12);
 
-      const key = `${createdAt.getFullYear()}-${createdAt.getMonth()}-${createdAt.getDate()}`;
+      const key = formatDateKey(createdAt);
       const existing = totalsByDate.get(key);
 
       if (existing) {

--- a/pnpm-monorepo/apps/app/src/modules/statistics/queries/getVariantShipStatisticChart.ts
+++ b/pnpm-monorepo/apps/app/src/modules/statistics/queries/getVariantShipStatisticChart.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/db";
 import { requireAuthentication } from "@/modules/auth/server";
 import { withTrace } from "@/modules/tracing/utils/withTrace";
+import { subHours } from "date-fns";
 import { forbidden } from "next/navigation";
 import { cache } from "react";
 import { buildChartData } from "../utils/chartData";
@@ -35,17 +36,15 @@ export const getVariantShipStatisticChart = cache(
       },
     });
 
-    const records = rows.map((row) => {
-      const createdAt = new Date(row.createdAt);
-      createdAt.setDate(createdAt.getDate() - 1); // Workaround: Offset due to timezone
-
-      return {
-        id: row.variantId,
-        name: row.variant.name,
-        createdAt,
-        count: row.count,
-      };
-    });
+    const records = rows.map((row) => ({
+      id: row.variantId,
+      name: row.variant.name,
+      // The snapshot is written moments after midnight (Europe/Berlin) and
+      // describes the day that just ended. Stepping back half a day lands
+      // inside that day regardless of DST shifts.
+      createdAt: subHours(row.createdAt, 12),
+      count: row.count,
+    }));
 
     return {
       ...buildChartData(records, configuration),

--- a/pnpm-monorepo/apps/playwright/playwright.config.ts
+++ b/pnpm-monorepo/apps/playwright/playwright.config.ts
@@ -20,4 +20,20 @@ export default defineConfig({
     // catch elements mid-animation.
     contextOptions: { reducedMotion: "reduce" },
   },
+
+  projects: [
+    {
+      // Talks to the collab container over plain HTTP and must not share a
+      // worker stack with tests whose websocket editing sessions' teardown
+      // writes race the database reset (can deadlock the collab container).
+      // Workers are never shared across projects, so this always runs on a
+      // fresh stack.
+      name: "collab-http",
+      testMatch: /collab-replace\.spec\.ts/,
+    },
+    {
+      name: "app",
+      testIgnore: /collab-replace\.spec\.ts/,
+    },
+  ],
 });

--- a/pnpm-monorepo/apps/playwright/tests/collab-replace.spec.ts
+++ b/pnpm-monorepo/apps/playwright/tests/collab-replace.spec.ts
@@ -1,0 +1,105 @@
+import { createHmac } from "node:crypto";
+import {
+  createCitizen,
+  createWikiPage,
+  WikiPageVisibility,
+} from "../fixtures/factories";
+import { expect, test } from "../fixtures/test";
+import { collabJwtSecret } from "../setup/stack";
+
+/**
+ * The internal replace endpoint authenticates with a short-lived HS256 JWT
+ * (claims: scope/pageId/entityId) signed with the shared collab secret —
+ * hand-rolled here so the test needs no jose dependency.
+ */
+const signReplaceToken = (pageId: string, entityId: string | null) => {
+  const encode = (value: object) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  const header = encode({ alg: "HS256", typ: "JWT" });
+  const payload = encode({
+    scope: "replace",
+    pageId,
+    entityId,
+    exp: Math.floor(Date.now() / 1000) + 60,
+  });
+  const signature = createHmac("sha256", collabJwtSecret)
+    .update(`${header}.${payload}`)
+    .digest("base64url");
+  return `${header}.${payload}.${signature}`;
+};
+
+/**
+ * Runs in its own Playwright project (see playwright.config.ts) and
+ * therefore in its own worker with a fresh stack: a websocket editing
+ * session's teardown writes (final store, audit event) race the next test's
+ * TRUNCATE and can deadlock the collab container, killing direct HTTP
+ * requests — so this test must never share a stack with editor tests.
+ */
+test("a programmatic /replace creates suppressed links only", async ({
+  collabHttpUrl,
+  prisma,
+}) => {
+  const author = await createCitizen(prisma, { handle: "author" });
+  const mentioned = await createCitizen(prisma, { handle: "Zielperson" });
+  const wikiPage = await createWikiPage(prisma, {
+    title: "Transplantat",
+    visibility: WikiPageVisibility.PUBLIC,
+  });
+
+  /**
+   * Node's fetch instead of Playwright's request fixture (whose client
+   * trips over Hocuspocus' plain-HTTP handling), retried in case the
+   * freshly started collab container isn't serving HTTP yet. A genuinely
+   * broken endpoint still fails every attempt.
+   */
+  await expect(async () => {
+    const response = await fetch(`${collabHttpUrl}/replace`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${signReplaceToken(wikiPage.id, author.entity.id)}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "wikiCitizenMention",
+                  attrs: {
+                    citizenId: mentioned.entity.id,
+                    handle: "Zielperson",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    });
+    expect(response.ok).toBe(true);
+  }).toPass({ timeout: 15_000 });
+
+  await expect
+    .poll(
+      () =>
+        prisma.wikiPageCitizenMention.findUnique({
+          where: {
+            pageId_citizenId: {
+              pageId: wikiPage.id,
+              citizenId: mentioned.entity.id,
+            },
+          },
+          select: { suppressedAt: true, notifiedAt: true },
+        }),
+      { timeout: 20_000 },
+    )
+    .toEqual({ suppressedAt: expect.any(Date), notifiedAt: null });
+
+  const pendingCount = await prisma.wikiPageCitizenMention.count({
+    where: { pageId: wikiPage.id, suppressedAt: null },
+  });
+  expect(pendingCount).toBe(0);
+});

--- a/pnpm-monorepo/apps/playwright/tests/notification-center.spec.ts
+++ b/pnpm-monorepo/apps/playwright/tests/notification-center.spec.ts
@@ -41,7 +41,8 @@ test("unread notifications drive the bell dot and the tab title", async ({
 
   await page.goto("/app");
 
-  await expect(page).toHaveTitle(/^\(2\)/);
+  // Often the worker's first page load — warm-up can exceed the default 5s
+  await expect(page).toHaveTitle(/^\(2\)/, { timeout: 15_000 });
   await expect(bellButton(page).locator(".bg-amber-500").first()).toBeVisible();
 });
 

--- a/pnpm-monorepo/apps/playwright/tests/notification-center.spec.ts
+++ b/pnpm-monorepo/apps/playwright/tests/notification-center.spec.ts
@@ -435,13 +435,11 @@ test.describe("mobile", () => {
     await expect(page).toHaveTitle(/^\(1\)/);
 
     await page.locator("nav").getByRole("button", { name: "Apps" }).click();
+    await openNotificationCenter(page);
 
-    await expect(
-      page.getByRole("button", { name: "Posteingang" }),
-    ).toBeVisible();
-    await expect(page.getByText("Neues Event")).toBeVisible();
+    await expect(popover(page).getByText("Neues Event")).toBeVisible();
 
-    await expect(page.getByTitle("Ungelesen", { exact: true })).toHaveCount(0, {
+    await expect(unreadRowDots(page)).toHaveCount(0, {
       timeout: READ_ON_VIEW_TIMEOUT,
     });
     await expect(page).toHaveTitle(/^[^(]/);

--- a/pnpm-monorepo/apps/playwright/tests/wiki-copy-paste.spec.ts
+++ b/pnpm-monorepo/apps/playwright/tests/wiki-copy-paste.spec.ts
@@ -269,11 +269,21 @@ test("replace mode transplants the copy onto an existing page", async ({
       where: { title: "Altes Kind", parentId: target.id },
     }),
   ).toBe(1);
-  expect(
-    await prisma.wikiPage.count({
-      where: { title: "Muster-Kind", parentId: target.id },
-    }),
-  ).toBe(1);
+  /**
+   * The action copies the children only after the collab replace, whose
+   * store debounce already satisfies the searchText poll above — so the
+   * action may still be running here. Poll until the child copy lands;
+   * this also orders the "no (Kopie) page" check below after the action.
+   */
+  await expect
+    .poll(
+      () =>
+        prisma.wikiPage.count({
+          where: { title: "Muster-Kind", parentId: target.id },
+        }),
+      { timeout: 15_000 },
+    )
+    .toBe(1);
   // No "(Kopie)" page was created — the target itself was replaced
   expect(
     await prisma.wikiPage.count({ where: { title: "Muster (Kopie)" } }),

--- a/pnpm-monorepo/apps/playwright/tests/wiki-mentions.spec.ts
+++ b/pnpm-monorepo/apps/playwright/tests/wiki-mentions.spec.ts
@@ -1,4 +1,3 @@
-import { createHmac } from "node:crypto";
 import {
   createCitizen,
   createWikiPage,
@@ -6,7 +5,6 @@ import {
   WikiPageVisibility,
 } from "../fixtures/factories";
 import { expect, test } from "../fixtures/test";
-import { collabJwtSecret } from "../setup/stack";
 
 /**
  * The editor swallows clicks near block edges (invisible hover-menu
@@ -48,103 +46,6 @@ const insertMention = async (
     .first()
     .click();
 };
-
-/**
- * The internal replace endpoint authenticates with a short-lived HS256 JWT
- * (claims: scope/pageId/entityId) signed with the shared collab secret —
- * hand-rolled here so the test needs no jose dependency.
- */
-const signReplaceToken = (pageId: string, entityId: string | null) => {
-  const encode = (value: object) =>
-    Buffer.from(JSON.stringify(value)).toString("base64url");
-  const header = encode({ alg: "HS256", typ: "JWT" });
-  const payload = encode({
-    scope: "replace",
-    pageId,
-    entityId,
-    exp: Math.floor(Date.now() / 1000) + 60,
-  });
-  const signature = createHmac("sha256", collabJwtSecret)
-    .update(`${header}.${payload}`)
-    .digest("base64url");
-  return `${header}.${payload}.${signature}`;
-};
-
-/**
- * Runs before any editor test: a websocket editing session's teardown
- * writes (final store, audit event) race the next test's TRUNCATE and
- * can deadlock the collab container, killing direct HTTP requests.
- */
-test("a programmatic /replace creates suppressed links only", async ({
-  collabHttpUrl,
-  prisma,
-}) => {
-  const author = await createCitizen(prisma, { handle: "author" });
-  const mentioned = await createCitizen(prisma, { handle: "Zielperson" });
-  const wikiPage = await createWikiPage(prisma, {
-    title: "Transplantat",
-    visibility: WikiPageVisibility.PUBLIC,
-  });
-
-  /**
-   * Node's fetch instead of Playwright's request fixture (whose client
-   * trips over Hocuspocus' plain-HTTP handling), retried because a
-   * preceding editor test's teardown writes can briefly disturb the collab
-   * container (they race the databaseReset TRUNCATE — an occasional
-   * ECONNRESET right after). A genuinely broken endpoint still fails
-   * every attempt.
-   */
-  await expect(async () => {
-    const response = await fetch(`${collabHttpUrl}/replace`, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${signReplaceToken(wikiPage.id, author.entity.id)}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        content: {
-          type: "doc",
-          content: [
-            {
-              type: "paragraph",
-              content: [
-                {
-                  type: "wikiCitizenMention",
-                  attrs: {
-                    citizenId: mentioned.entity.id,
-                    handle: "Zielperson",
-                  },
-                },
-              ],
-            },
-          ],
-        },
-      }),
-    });
-    expect(response.ok).toBe(true);
-  }).toPass({ timeout: 15_000 });
-
-  await expect
-    .poll(
-      () =>
-        prisma.wikiPageCitizenMention.findUnique({
-          where: {
-            pageId_citizenId: {
-              pageId: wikiPage.id,
-              citizenId: mentioned.entity.id,
-            },
-          },
-          select: { suppressedAt: true, notifiedAt: true },
-        }),
-      { timeout: 20_000 },
-    )
-    .toEqual({ suppressedAt: expect.any(Date), notifiedAt: null });
-
-  const pendingCount = await prisma.wikiPageCitizenMention.count({
-    where: { pageId: wikiPage.id, suppressedAt: null },
-  });
-  expect(pendingCount).toBe(0);
-});
 
 test("an @mention creates a pending link, removing it deletes the link", async ({
   page,


### PR DESCRIPTION
Phase 1 of the 2026-08 project maintenance plan: every confirmed live bug fixed in isolation, one commit per concern, before any refactoring.

## Fixes

- **API error handler**: zod v4 removed `ZodError.errors`, so 400 responses carried `errors: undefined` — now serializes `error.issues`.
- **Profit distribution**: ending a collection phase now emits the `SilcTransactionsCreated` notification like every other SILC path.
- **Statistics charts**: date keys are now built with `formatInTimeZone` (Europe/Berlin) across seven queries. The registered-user, total-citizen and total-organization charts were flatlining because their server-local keys never matched the axis keys; the snapshot charts' ±1-day mutation hacks broke around DST on UTC servers; the daily-login chart displayed counts one day late. Charts will visibly change — that is the correction.
- **Dashboard**: citizens without `task;read` got a fully redacted dashboard because the task tiles' queries call `forbidden()` unguarded — the tiles are now permission-gated like the calendar tile.
- **Feature flags**: `getUnleashFlag` returned `undefined` (typed `boolean`) when flag evaluation threw.
- **Preview channel**: the countdown interval was torn down and recreated on every render.
- **Auth**: the client-side `enable_admin` cookie check matched by substring (e.g. `not_enable_admin=1`).
- **CI**: PRs touching only `pnpm-monorepo/packages/**` (other than `database`) ran no validation at all.

## Test changes

- The collab `/replace` test relied on undocumented ordering under `fullyParallel`; it now runs in a dedicated Playwright project and therefore always on a fresh worker stack.
- The mobile notification-center test still exercised the inline flyout UI replaced by 60d4914c and is updated to the popover flow.
- Two racy assertions that flaked under load were made deterministic (completion-barrier poll, cold-start headroom).

## Verification

- Unit tests: 295 passed / 1 skipped (baseline match); typecheck and production build green.
- Playwright: full suite green twice consecutively (40/40, zero retries) after the fixes; the wiki-copy-paste flake was reproduced on `main` beforehand to confirm pre-existence.
- Statistics key logic spot-checked around both 2026 DST boundaries under `TZ=UTC` and `TZ=Europe/Berlin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171TTomuonTYBUiDyucK9Cd