### PR TITLE
ci: verify the packages path filter triggers the unit tests

### DIFF
--- a/pnpm-monorepo/packages/permissions/src/index.ts
+++ b/pnpm-monorepo/packages/permissions/src/index.ts
@@ -31,3 +31,5 @@ export {
   type WikiPermissionRole,
 } from "./resolveWikiPageRolePermissions.js";
 export { transformPermissionStringToPermissionSet } from "./transformPermissionStringToPermissionSet.js";
+
+// Temporary CI path-filter verification (this PR is closed without merging).


### PR DESCRIPTION
Temporary verification PR from the 2026-08 maintenance plan (Phase 3 pending verification): confirms a PR touching only `pnpm-monorepo/packages/**` triggers the Validate app workflow (unit tests + typecheck). Will be closed without merging once the checks have run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5Q1UbuTDjKsmAkVU6u9Ue