### PR TITLE
ci: verify lambda-only changes skip the Playwright suite

### DIFF
--- a/pnpm-monorepo/apps/lambda/src/email-function.ts
+++ b/pnpm-monorepo/apps/lambda/src/email-function.ts
@@ -1,3 +1,4 @@
+// Temporary CI path-filter verification (this PR is closed without merging).
 import "./email-function/setup";
 
 import type { SQSBatchItemFailure, SQSHandler } from "aws-lambda";


### PR DESCRIPTION
Temporary verification PR from the 2026-08 maintenance plan (Phase 3 pending verification): confirms a PR touching only `pnpm-monorepo/apps/lambda/**` does NOT trigger the scoped Playwright workflow. Will be closed without merging once the check-set is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5Q1UbuTDjKsmAkVU6u9Ue