### PR TITLE
ci: verify the lint gate blocks on a deliberate lint error

### DIFF
--- a/pnpm-monorepo/apps/app/src/modules/common/components/LintGateCheck.tsx
+++ b/pnpm-monorepo/apps/app/src/modules/common/components/LintGateCheck.tsx
@@ -1,0 +1,4 @@
+// Temporary CI lint-gate verification (this PR is closed without merging).
+export const LintGateCheck = () => {
+  return <p>Deliberate lint error: it's an unescaped entity</p>;
+};


### PR DESCRIPTION
Temporary verification PR from the 2026-08 maintenance plan (Phase 4 pending verification): confirms the lint job — now without `continue-on-error` — fails a PR containing a lint error (`react/no-unescaped-entities`, verified failing locally). Will be closed without merging once the lint job has failed as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5Q1UbuTDjKsmAkVU6u9Ue